### PR TITLE
Add previous missing and invalid TLDs

### DIFF
--- a/tld.sh
+++ b/tld.sh
@@ -23,6 +23,6 @@ EOF
 }
 
 for tld in $TLDs; do
-    [[ $SKIP =~ .*$tld.* ]] && continue
+    [[ $SKIP =~ (^|.*[[:space:]])$tld([[:space:]].*|$) ]] && continue
     config $tld
 done

--- a/tld.sh
+++ b/tld.sh
@@ -7,7 +7,10 @@ curl https://gist.githubusercontent.com/thde/3890aa48e03a2b551374/raw/138589bfca
 TLDs=$(cut -d " " -f1 whois.conf | sed -e 's/\\//' -e 's/\.//' -e 's/\$//' | egrep -v '^$|^#')
 
 # Skip existing supported TLDs
-SKIP=$(grep = ./whois/tld_regexpr.py | cut -d " " -f1)
+# Skip commented TLDs
+# Remove underscore at end of TLDs
+# Replace underscore with hypen
+SKIP=$(grep = ./whois/tld_regexpr.py | sed -e 's/^#//g' -e 's/_\s/ /' -e 's/_/-/g' | cut -d " " -f1)
 
 config(){
 tld="$1"

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -27,8 +27,12 @@ def query(domain, host=None, force=0, cache_file=None, slow_down=0, ignore_retur
         tld = 'co_jp'
     elif domain.endswith('.рф') or domain.endswith('.xn--p1ai'):
         tld = 'ru_rf'
-    elif domain.endswith('.in'):
-        tld = 'IN'
+    elif domain.endswith(('.as','.global','.help','.id','.in','.int','.is','.next','.property','.zip')):
+        # Convert TLD which matches a Python function/keyword by adding suffix
+        tld = d[-1] + '_'
+    elif '-' in domain:
+        # Convert invalid dict name
+        tld = d[-1].replace('-', '_')
     else:
         tld = d[-1]
 

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -516,6 +516,9 @@ alsace = {
 alstom = {
   'extend': 'com',
 }
+am = {
+  'extend': 'com',
+}
 americanfamily = {
   'extend': 'com',
 }
@@ -685,6 +688,9 @@ bet = {
   'extend': 'com',
 }
 bg = {
+  'extend': 'com',
+}
+bi = {
   'extend': 'com',
 }
 bid = {
@@ -1437,6 +1443,9 @@ flsmidth = {
 fly = {
   'extend': 'com',
 }
+fo = {
+  'extend': 'com',
+}
 foodnetwork = {
   'extend': 'com',
 }
@@ -2043,6 +2052,9 @@ lexus = {
 lgbt = {
   'extend': 'com',
 }
+li = {
+  'extend': 'com',
+}
 liaison = {
   'extend': 'com',
 }
@@ -2325,6 +2337,9 @@ my = {
 mz = {
   'extend': 'com',
 }
+na = {
+  'extend': 'com',
+}
 nab = {
   'extend': 'com',
 }
@@ -2373,6 +2388,9 @@ next_ = {
 nexus = {
   'extend': 'com',
 }
+nf = {
+  'extend': 'com',
+}
 ng = {
   'extend': 'com',
 }
@@ -2393,6 +2411,14 @@ nissan = {
 }
 nissay = {
   'extend': 'com',
+}
+nl = {
+  'extend': 'com',
+
+  'status': r'Status:\s?(.+)',
+  'name_servers': r'Domain nameservers:\n?(.+)\n?(.+)\n?(.+)',
+  'registrar_abuse_contact_email' : r'Abuse Contact:\s.+\s(.+@[\w.-]+\.[\w]{2,4})',
+  'registrar_abuse_contact_phone': r'Abuse Contact:\s(\s+\+.+)',
 }
 no = {
   'extend': 'com',
@@ -2442,7 +2468,13 @@ olayan = {
 ollo = {
   'extend': 'com',
 }
+om = {
+  'extend': 'com',
+}
 omega = {
+  'extend': 'com',
+}
+onl = {
   'extend': 'com',
 }
 one = {

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -564,10 +564,9 @@ arte = {
 art = {
   'extend': 'com',
 }
-# as is Python keyword
-#as = {
-#  'extend': 'com',
-#}
+as_ = {
+  'extend': 'com',
+}
 asda = {
   'extend': 'com',
 }
@@ -1570,11 +1569,9 @@ gle = {
 gl = {
   'extend': 'com',
 }
-
-# global is python keyword
-#global = {
-#  'extend': 'com',
-#}
+global_ = {
+  'extend': 'com',
+}
 globo = {
   'extend': 'com',
 }
@@ -1674,7 +1671,7 @@ hdfc = {
 healthcare = {
   'extend': 'com',
 }
-help = {
+help_ = {
   'extend': 'com',
 }
 helsinki = {
@@ -1773,7 +1770,7 @@ ice = {
 icu = {
   'extend': 'com',
 }
-id = {
+id_ = {
   'extend': 'com',
 }
 ie = {
@@ -1803,8 +1800,7 @@ immobilien = {
 immo = {
   'extend': 'com',
 }
-#Using "IN" as "in" is a keyword in python
-IN = {
+in_ = {
     'extend': 'com',
 }
 industries = {
@@ -1831,7 +1827,7 @@ insure = {
 international = {
   'extend': 'com',
 }
-int = {
+int_ = {
   'extend': 'com',
 }
 investments = {
@@ -1852,10 +1848,9 @@ irish = {
 iselect = {
   'extend': 'com',
 }
-# is is a Python keyword
-#is = {
-#  'extend': 'com',
-#}
+is_ = {
+  'extend': 'com',
+}
 ismaili = {
   'extend': 'com',
 }
@@ -2372,7 +2367,7 @@ news = {
 nextdirect = {
   'extend': 'com',
 }
-next = {
+next_ = {
   'extend': 'com',
 }
 nexus = {
@@ -2618,7 +2613,7 @@ promo = {
 properties = {
   'extend': 'com',
 }
-property = {
+property_ = {
   'extend': 'com',
 }
 protection = {
@@ -3503,319 +3498,318 @@ xihuan = {
 xin = {
   'extend': 'com',
 }
-# Invalid dict name
-#xn--11b4c3d = {
-#  'extend': 'com',
-#}
-#xn--1qqw23a = {
-#  'extend': 'com',
-#}
-#xn--30rr7y = {
-#  'extend': 'com',
-#}
-#xn--3bst00m = {
-#  'extend': 'com',
-#}
-#xn--3ds443g = {
-#  'extend': 'com',
-#}
-#xn--3e0b707e = {
-#  'extend': 'com',
-#}
-#xn--3oq18vl8pn36a = {
-#  'extend': 'com',
-#}
-#xn--3pxu8k = {
-#  'extend': 'com',
-#}
-#xn--42c2d9a = {
-#  'extend': 'com',
-#}
-#xn--45q11c = {
-#  'extend': 'com',
-#}
-#xn--4gbrim = {
-#  'extend': 'com',
-#}
-#xn--55qw42g = {
-#  'extend': 'com',
-#}
-#xn--55qx5d = {
-#  'extend': 'com',
-#}
-#xn--5su34j936bgsg = {
-#  'extend': 'com',
-#}
-#xn--5tzm5g = {
-#  'extend': 'com',
-#}
-#xn--6frz82g = {
-#  'extend': 'com',
-#}
-#xn--6qq986b3xl = {
-#  'extend': 'com',
-#}
-#xn--80adxhks = {
-#  'extend': 'com',
-#}
-#xn--80ao21a = {
-#  'extend': 'com',
-#}
-#xn--80aqecdr1a = {
-#  'extend': 'com',
-#}
-#xn--80asehdb = {
-#  'extend': 'com',
-#}
-#xn--80aswg = {
-#  'extend': 'com',
-#}
-#xn--90a3ac = {
-#  'extend': 'com',
-#}
-#xn--90ae = {
-#  'extend': 'com',
-#}
-#xn--90ais = {
-#  'extend': 'com',
-#}
-#xn--9dbq2a = {
-#  'extend': 'com',
-#}
-#xn--9et52u = {
-#  'extend': 'com',
-#}
-#xn--9krt00a = {
-#  'extend': 'com',
-#}
-#xn--b4w605ferd = {
-#  'extend': 'com',
-#}
-#xn--c1avg = {
-#  'extend': 'com',
-#}
-#xn--c2br7g = {
-#  'extend': 'com',
-#}
-#xn--cg4bki = {
-#  'extend': 'com',
-#}
-#xn--clchc0ea0b2g2a9gcd = {
-#  'extend': 'com',
-#}
-#xn--czrs0t = {
-#  'extend': 'com',
-#}
-#xn--czru2d = {
-#  'extend': 'com',
-#}
-#xn--d1acj3b = {
-#  'extend': 'com',
-#}
-#xn--d1alf = {
-#  'extend': 'com',
-#}
-#xn--e1a4c = {
-#  'extend': 'com',
-#}
-#xn--efvy88h = {
-#  'extend': 'com',
-#}
-#xn--estv75g = {
-#  'extend': 'com',
-#}
-#xn--fhbei = {
-#  'extend': 'com',
-#}
-#xn--fiq228c5hs = {
-#  'extend': 'com',
-#}
-#xn--fiq64b = {
-#  'extend': 'com',
-#}
-#xn--fiqs8s = {
-#  'extend': 'com',
-#}
-#xn--fiqz9s = {
-#  'extend': 'com',
-#}
-#xn--fjq720a = {
-#  'extend': 'com',
-#}
-#xn--flw351e = {
-#  'extend': 'com',
-#}
-#xn--fzys8d69uvgm = {
-#  'extend': 'com',
-#}
-#xn--hxt814e = {
-#  'extend': 'com',
-#}
-#xn--i1b6b1a6a2e = {
-#  'extend': 'com',
-#}
-#xn--io0a7i = {
-#  'extend': 'com',
-#}
-#xn--j1aef = {
-#  'extend': 'com',
-#}
-#xn--j1amh = {
-#  'extend': 'com',
-#}
-#xn--j6w193g = {
-#  'extend': 'com',
-#}
-#xn--jlq61u9w7b = {
-#  'extend': 'com',
-#}
-#xn--kcrx77d1x4a = {
-#  'extend': 'com',
-#}
-#xn--kprw13d = {
-#  'extend': 'com',
-#}
-#xn--kpry57d = {
-#  'extend': 'com',
-#}
-#xn--kput3i = {
-#  'extend': 'com',
-#}
-#xn--lgbbat1ad8j = {
-#  'extend': 'com',
-#}
-#xn--mgb9awbf = {
-#  'extend': 'com',
-#}
-#xn--mgba3a4f16a = {
-#  'extend': 'com',
-#}
-#xn--mgba7c0bbn0a = {
-#  'extend': 'com',
-#}
-#xn--mgbaam7a8h = {
-#  'extend': 'com',
-#}
-#xn--mgbab2bd = {
-#  'extend': 'com',
-#}
-#xn--mgbca7dzdo = {
-#  'extend': 'com',
-#}
-#xn--mgberp4a5d4ar = {
-#  'extend': 'com',
-#}
-#xn--mgbi4ecexp = {
-#  'extend': 'com',
-#}
-#xn--mgbt3dhd = {
-#  'extend': 'com',
-#}
-#xn--mgbtx2b = {
-#  'extend': 'com',
-#}
-#xn--mgbx4cd0ab = {
-#  'extend': 'com',
-#}
-#xn--mix891f = {
-#  'extend': 'com',
-#}
-#xn--mk1bu44c = {
-#  'extend': 'com',
-#}
-#xn--mxtq1m = {
-#  'extend': 'com',
-#}
-#xn--ngbc5azd = {
-#  'extend': 'com',
-#}
-#xn--ngbe9e0a = {
-#  'extend': 'com',
-#}
-#xn--node = {
-#  'extend': 'com',
-#}
-#xn--nqv7f = {
-#  'extend': 'com',
-#}
-#xn--nqv7fs00ema = {
-#  'extend': 'com',
-#}
-#xn--o3cw4h = {
-#  'extend': 'com',
-#}
-#xn--ogbpf8fl = {
-#  'extend': 'com',
-#}
-#xn--p1acf = {
-#  'extend': 'com',
-#}
-#xn--p1ai = {
-#  'extend': 'com',
-#}
-#xn--pssy2u = {
-#  'extend': 'com',
-#}
-#xn--q9jyb4c = {
-#  'extend': 'com',
-#}
-#xn--qcka1pmc = {
-#  'extend': 'com',
-#}
-#xn--rhqv96g = {
-#  'extend': 'com',
-#}
-#xn--ses554g = {
-#  'extend': 'com',
-#}
-#xn--t60b56a = {
-#  'extend': 'com',
-#}
-#xn--tckwe = {
-#  'extend': 'com',
-#}
-#xn--tiq49xqyj = {
-#  'extend': 'com',
-#}
-#xn--unup4y = {
-#  'extend': 'com',
-#}
-#xn--vermgensberater-ctb = {
-#  'extend': 'com',
-#}
-#xn--vermgensberatung-pwb = {
-#  'extend': 'com',
-#}
-#xn--vhquv = {
-#  'extend': 'com',
-#}
-#xn--vuq861b = {
-#  'extend': 'com',
-#}
-#xn--w4r85el8fhu5dnra = {
-#  'extend': 'com',
-#}
-#xn--w4rs40l = {
-#  'extend': 'com',
-#}
-#xn--wgbl6a = {
-#  'extend': 'com',
-#}
-#xn--xhq521b = {
-#  'extend': 'com',
-#}
-#xn--y9a3aq = {
-#  'extend': 'com',
-#}
-#xn--yfro4i67o = {
-#  'extend': 'com',
-#}
-#xn--ygbi2ammx = {
-#  'extend': 'com',
-#}
-#xn--zfr164b = {
-#  'extend': 'com',
-#}
+xn__11b4c3d = {
+  'extend': 'com',
+}
+xn__1qqw23a = {
+  'extend': 'com',
+}
+xn__30rr7y = {
+  'extend': 'com',
+}
+xn__3bst00m = {
+  'extend': 'com',
+}
+xn__3ds443g = {
+  'extend': 'com',
+}
+xn__3e0b707e = {
+  'extend': 'com',
+}
+xn__3oq18vl8pn36a = {
+  'extend': 'com',
+}
+xn__3pxu8k = {
+  'extend': 'com',
+}
+xn__42c2d9a = {
+  'extend': 'com',
+}
+xn__45q11c = {
+  'extend': 'com',
+}
+xn__4gbrim = {
+  'extend': 'com',
+}
+xn__55qw42g = {
+  'extend': 'com',
+}
+xn__55qx5d = {
+  'extend': 'com',
+}
+xn__5su34j936bgsg = {
+  'extend': 'com',
+}
+xn__5tzm5g = {
+  'extend': 'com',
+}
+xn__6frz82g = {
+  'extend': 'com',
+}
+xn__6qq986b3xl = {
+  'extend': 'com',
+}
+xn__80adxhks = {
+  'extend': 'com',
+}
+xn__80ao21a = {
+  'extend': 'com',
+}
+xn__80aqecdr1a = {
+  'extend': 'com',
+}
+xn__80asehdb = {
+  'extend': 'com',
+}
+xn__80aswg = {
+  'extend': 'com',
+}
+xn__90a3ac = {
+  'extend': 'com',
+}
+xn__90ae = {
+  'extend': 'com',
+}
+xn__90ais = {
+  'extend': 'com',
+}
+xn__9dbq2a = {
+  'extend': 'com',
+}
+xn__9et52u = {
+  'extend': 'com',
+}
+xn__9krt00a = {
+  'extend': 'com',
+}
+xn__b4w605ferd = {
+  'extend': 'com',
+}
+xn__c1avg = {
+  'extend': 'com',
+}
+xn__c2br7g = {
+  'extend': 'com',
+}
+xn__cg4bki = {
+  'extend': 'com',
+}
+xn__clchc0ea0b2g2a9gcd = {
+  'extend': 'com',
+}
+xn__czrs0t = {
+  'extend': 'com',
+}
+xn__czru2d = {
+  'extend': 'com',
+}
+xn__d1acj3b = {
+  'extend': 'com',
+}
+xn__d1alf = {
+  'extend': 'com',
+}
+xn__e1a4c = {
+  'extend': 'com',
+}
+xn__efvy88h = {
+  'extend': 'com',
+}
+xn__estv75g = {
+  'extend': 'com',
+}
+xn__fhbei = {
+  'extend': 'com',
+}
+xn__fiq228c5hs = {
+  'extend': 'com',
+}
+xn__fiq64b = {
+  'extend': 'com',
+}
+xn__fiqs8s = {
+  'extend': 'com',
+}
+xn__fiqz9s = {
+  'extend': 'com',
+}
+xn__fjq720a = {
+  'extend': 'com',
+}
+xn__flw351e = {
+  'extend': 'com',
+}
+xn__fzys8d69uvgm = {
+  'extend': 'com',
+}
+xn__hxt814e = {
+  'extend': 'com',
+}
+xn__i1b6b1a6a2e = {
+  'extend': 'com',
+}
+xn__io0a7i = {
+  'extend': 'com',
+}
+xn__j1aef = {
+  'extend': 'com',
+}
+xn__j1amh = {
+  'extend': 'com',
+}
+xn__j6w193g = {
+  'extend': 'com',
+}
+xn__jlq61u9w7b = {
+  'extend': 'com',
+}
+xn__kcrx77d1x4a = {
+  'extend': 'com',
+}
+xn__kprw13d = {
+  'extend': 'com',
+}
+xn__kpry57d = {
+  'extend': 'com',
+}
+xn__kput3i = {
+  'extend': 'com',
+}
+xn__lgbbat1ad8j = {
+  'extend': 'com',
+}
+xn__mgb9awbf = {
+  'extend': 'com',
+}
+xn__mgba3a4f16a = {
+  'extend': 'com',
+}
+xn__mgba7c0bbn0a = {
+  'extend': 'com',
+}
+xn__mgbaam7a8h = {
+  'extend': 'com',
+}
+xn__mgbab2bd = {
+  'extend': 'com',
+}
+xn__mgbca7dzdo = {
+  'extend': 'com',
+}
+xn__mgberp4a5d4ar = {
+  'extend': 'com',
+}
+xn__mgbi4ecexp = {
+  'extend': 'com',
+}
+xn__mgbt3dhd = {
+  'extend': 'com',
+}
+xn__mgbtx2b = {
+  'extend': 'com',
+}
+xn__mgbx4cd0ab = {
+  'extend': 'com',
+}
+xn__mix891f = {
+  'extend': 'com',
+}
+xn__mk1bu44c = {
+  'extend': 'com',
+}
+xn__mxtq1m = {
+  'extend': 'com',
+}
+xn__ngbc5azd = {
+  'extend': 'com',
+}
+xn__ngbe9e0a = {
+  'extend': 'com',
+}
+xn__node = {
+  'extend': 'com',
+}
+xn__nqv7f = {
+  'extend': 'com',
+}
+xn__nqv7fs00ema = {
+  'extend': 'com',
+}
+xn__o3cw4h = {
+  'extend': 'com',
+}
+xn__ogbpf8fl = {
+  'extend': 'com',
+}
+xn__p1acf = {
+  'extend': 'com',
+}
+xn__p1ai = {
+  'extend': 'com',
+}
+xn__pssy2u = {
+  'extend': 'com',
+}
+xn__q9jyb4c = {
+  'extend': 'com',
+}
+xn__qcka1pmc = {
+  'extend': 'com',
+}
+xn__rhqv96g = {
+  'extend': 'com',
+}
+xn__ses554g = {
+  'extend': 'com',
+}
+xn__t60b56a = {
+  'extend': 'com',
+}
+xn__tckwe = {
+  'extend': 'com',
+}
+xn__tiq49xqyj = {
+  'extend': 'com',
+}
+xn__unup4y = {
+  'extend': 'com',
+}
+xn__vermgensberater_ctb = {
+  'extend': 'com',
+}
+xn__vermgensberatung_pwb = {
+  'extend': 'com',
+}
+xn__vhquv = {
+  'extend': 'com',
+}
+xn__vuq861b = {
+  'extend': 'com',
+}
+xn__w4r85el8fhu5dnra = {
+  'extend': 'com',
+}
+xn__w4rs40l = {
+  'extend': 'com',
+}
+xn__wgbl6a = {
+  'extend': 'com',
+}
+xn__xhq521b = {
+  'extend': 'com',
+}
+xn__y9a3aq = {
+  'extend': 'com',
+}
+xn__yfro4i67o = {
+  'extend': 'com',
+}
+xn__ygbi2ammx = {
+  'extend': 'com',
+}
+xn__zfr164b = {
+  'extend': 'com',
+}
 xperia = {
   'extend': 'com',
 }
@@ -3846,7 +3840,7 @@ yun = {
 zara = {
   'extend': 'com',
 }
-zip = {
+zip_ = {
   'extend': 'com',
 }
 zm = {


### PR DESCRIPTION

I initially started to just find out why `.nl` was not supported.

This PR contains 116 TLDs that were either not supported because the TLD is an invalid Python dict name or was omitted because it slipped through the `tld.sh` check

Invalid dict because it contained hypens: 104  
Invalid dict because it is a Python keyword: 3  
Missed because it slipped through `tld.sh`: 9  

<details>
  <summary> In total 116 added TLDs</summary>
  
- am
- as
- bi
- fo
- global
- is
- li
- na
- nf
- nl
- om
- onl
- xn--11b4c3d
- xn--1qqw23a
- xn--30rr7y
- xn--3bst00m
- xn--3ds443g
- xn--3e0b707e
- xn--3oq18vl8pn36a
- xn--3pxu8k
- xn--42c2d9a
- xn--45q11c
- xn--4gbrim
- xn--55qw42g
- xn--55qx5d
- xn--5su34j936bgsg
- xn--5tzm5g
- xn--6frz82g
- xn--6qq986b3xl
- xn--80adxhks
- xn--80ao21a
- xn--80aqecdr1a
- xn--80asehdb
- xn--80aswg
- xn--90a3ac
- xn--90ae
- xn--90ais
- xn--9dbq2a
- xn--9et52u
- xn--9krt00a
- xn--b4w605ferd
- xn--c1avg
- xn--c2br7g
- xn--cg4bki
- xn--clchc0ea0b2g2a9gcd
- xn--czrs0t
- xn--czru2d
- xn--d1acj3b
- xn--d1alf
- xn--e1a4c
- xn--efvy88h
- xn--estv75g
- xn--fhbei
- xn--fiq228c5hs
- xn--fiq64b
- xn--fiqs8s
- xn--fiqz9s
- xn--fjq720a
- xn--flw351e
- xn--fzys8d69uvgm
- xn--hxt814e
- xn--i1b6b1a6a2e
- xn--io0a7i
- xn--j1aef
- xn--j1amh
- xn--j6w193g
- xn--jlq61u9w7b
- xn--kcrx77d1x4a
- xn--kprw13d
- xn--kpry57d
- xn--kput3i
- xn--lgbbat1ad8j
- xn--mgb9awbf
- xn--mgba3a4f16a
- xn--mgba7c0bbn0a
- xn--mgbaam7a8h
- xn--mgbab2bd
- xn--mgbca7dzdo
- xn--mgberp4a5d4ar
- xn--mgbi4ecexp
- xn--mgbt3dhd
- xn--mgbtx2b
- xn--mgbx4cd0ab
- xn--mix891f
- xn--mk1bu44c
- xn--mxtq1m
- xn--ngbc5azd
- xn--ngbe9e0a
- xn--node
- xn--nqv7f
- xn--nqv7fs00ema
- xn--o3cw4h
- xn--ogbpf8fl
- xn--p1acf
- xn--p1ai
- xn--pssy2u
- xn--q9jyb4c
- xn--qcka1pmc
- xn--rhqv96g
- xn--ses554g
- xn--t60b56a
- xn--tckwe
- xn--tiq49xqyj
- xn--unup4y
- xn--vermgensberater-ctb
- xn--vermgensberatung-pwb
- xn--vhquv
- xn--vuq861b
- xn--w4r85el8fhu5dnra
- xn--w4rs40l
- xn--wgbl6a
- xn--xhq521b
- xn--y9a3aq
- xn--yfro4i67o
- xn--ygbi2ammx
- xn--zfr164b
</details>

<br>
For the invalid dict names the following will be applied:

- The TLDs with hypens will be converted to underscores
- The TLDs that match built-in Python
 functions and keywords will get an underscore suffix

The missing TLDs were because the regex check was too broad and would match inappropriately.
For example `.nl` wasn't added because it 'matched' as `.bnl`, thus `.nl` was skipped.

The `.nl` regex has been tested against the following : `nu.nl`, `google.nl`, `dtx.nl` and `sidn.nl`